### PR TITLE
Small improvements

### DIFF
--- a/MODULES/AB040MMU/AB040MOD.S
+++ b/MODULES/AB040MMU/AB040MOD.S
@@ -17,9 +17,9 @@ execute:
 	moveq #0,d0
 	movec d0,cacr
 	nop
-	dc.w $f4d8					;CINVA BC,(A0)
+	dc.w $f4d8					;CINVA BC
 	nop
-	dc.w $f518					;CPUSHA
+	dc.w $f518					;PFLUSHA
 	nop
 	move.l #$ffe000,d1
 	dc.w $4e7b,$1004		;MOVEC D1,ITT0

--- a/MODULES/MODSTART.PRJ
+++ b/MODULES/MODSTART.PRJ
@@ -1,4 +1,5 @@
 MODSTART.O
+.S[-U]
 .L[-J]
 =
 MODSTART.S


### PR DESCRIPTION
- clarify used 68040 instructions
- add `-U` for assembling MODSTART.S in case it is not enabled in Pure C shell

Btw I wonder why do you insist on having MODSTART.PRJ as a standalone project, you can reference MODSTART.S directly from e.g. SAMPLE.PRJ, no need for double compilation. It's literally one character change (`..\..\MODULES\MODSTART.O` => `..\..\MODULES\MODSTART.S`).